### PR TITLE
Retrieve today's date using the local timezone

### DIFF
--- a/src/date.janet
+++ b/src/date.janet
@@ -80,7 +80,7 @@
   {:year 2021 :month 12 :day 31 :week-day "Friday"}
   ```
   []
-  (let [today (os/date)]
+  (let [today (os/date (os/time) false)]
     @{:year (today :year)
       :month (+ (today :month) 1)
       :day (+ (today :month-day) 1)


### PR DESCRIPTION
This fixes #127. 

I abstained from adding a test as I have not found out how to handle different timezones with Janet's os package. (https://github.com/cosmictoast/janet-date does provide more flexibility in this regard)

There might be other bugs lurking when converting the dates back and forth.