### PR TITLE
Add support for body for events

### DIFF
--- a/src/event.janet
+++ b/src/event.janet
@@ -1,5 +1,5 @@
 ### ————————————————————————————————————————————————————————————————————————————————————————————————
 ### This module implements event entity and related functions.
 
-(defn build-event [title]
-  {:title title})
+(defn build-event [title &opt body]
+  {:title title :body body})

--- a/src/event.janet
+++ b/src/event.janet
@@ -1,5 +1,5 @@
-### ————————————————————————————————————————————————————————————————————————————
+### ————————————————————————————————————————————————————————————————————————————————————————————————
 ### This module implements event entity and related functions.
 
-(defn build-event [text]
-  {:text text})
+(defn build-event [title]
+  {:title title})

--- a/src/plan/parser.janet
+++ b/src/plan/parser.janet
@@ -27,8 +27,15 @@
           :events
             {:main (group (any :event))
              :event
-               {:main (replace (* :event-begin :text-line (? "\n")) ,event/build-event)
-                :event-begin (* "- " (not "["))}}}}
+               {:main (replace (* :event-begin
+                                  :text-line
+                                  (? "\n")
+                                  :event-body
+                                  (? "\n"))
+                               ,event/build-event)
+                :event-begin (* "- " (not "["))
+                :event-body {:main (group (any :event-body-line))
+                             :event-body-line (* "  " :text-line (? "\n"))}}}}}
     :tasks
       {:main (group (any :task))
        :task
@@ -78,7 +85,7 @@
                                plan
                                {:serialize-empty-inbox serialize-empty-inbox})]
       (if (= (lines-count parsed-plan-string) (lines-count plan-string))
-        {:plan plan}
+        {:plan plan :errors []}
         {:errors [(string "Plan can not be parsed: last parsed line is line "
                           (lines-count parsed-plan-string {:ignore-whitespace false}))]}))
     {:errors ["Plan can not be parsed"]}))

--- a/src/plan/serializer.janet
+++ b/src/plan/serializer.janet
@@ -12,7 +12,7 @@
   (if done "[X]" "[ ]"))
 
 (defn- serialize-event [event]
-  (string "- " (event :text)))
+  (string "- " (event :title)))
 
 (defn- task-mark [task]
   (if (task :missed-on)

--- a/src/plan/serializer.janet
+++ b/src/plan/serializer.janet
@@ -3,7 +3,7 @@
 
 (import ../date)
 
-(def task-body-indentation "  ")
+(def body-indentation "  ")
 
 (defn- plan-title [plan]
   (string "# " (plan :title)))
@@ -11,8 +11,22 @@
 (defn- checkbox [done]
   (if done "[X]" "[ ]"))
 
-(defn- serialize-event [event]
+(defn- serialize-event-title [event]
   (string "- " (event :title)))
+
+(defn- serialize-event-body [event]
+  (def body (event :body))
+  (if (or (nil? body) (empty? body))
+    ""
+    (string "\n"
+            (string/join
+              (map (fn [line] (string body-indentation line)) body)
+              "\n"))))
+
+(defn- serialize-event [event]
+  (string
+    (serialize-event-title event)
+    (serialize-event-body event)))
 
 (defn- task-mark [task]
   (if (task :missed-on)
@@ -28,11 +42,12 @@
     ""
     (string "\n"
             (string/join
-              (map (fn [line] (string task-body-indentation line)) body)
+              (map (fn [line] (string body-indentation line)) body)
               "\n"))))
 
 (defn- serialize-task [task]
-  (string (serialize-task-title task)
+  (string
+    (serialize-task-title task)
     (serialize-task-body task)))
 
 (defn- plan-inbox [plan serialize-empty-inbox]

--- a/test/plan/parser_test.janet
+++ b/test/plan/parser_test.janet
@@ -182,6 +182,28 @@
   (test (= (d/date 2020 8 1) (day-1 :date)) true)
   (test (= (d/date 2020 7 31) (day-2 :date)) true))
 
+(deftest "parses a plan with an event that has a body"
+  (def plan-string
+    ```
+    # Main TODO
+
+    ## 2020-07-30, Thursday
+
+    - Talked to Mike & Molly
+      - They moved to a new apartment
+    - [x] Fix the lamp
+    ```)
+  (def plan ((parse plan-string) :plan))
+  (test  (length (plan :days)) 1)
+  (let [day ((plan :days) 0)
+        event ((day :events) 0)
+        task ((day :tasks) 0)]
+    (test (event :title) "Talked to Mike & Molly")
+    (test ((event :body) 0) "- They moved to a new apartment")
+    (test (= (d/date 2020 7 30) (day :date)) true)
+    (test (task :title) "Fix the lamp")
+    (test (task :done) true)))
+
 (deftest "returns an error when the plan can't be parsed"
   (def plan-string
     ```

--- a/test/plan/parser_test.janet
+++ b/test/plan/parser_test.janet
@@ -51,7 +51,7 @@
     (test (not (task :done)) true)
     (test (d/equal? (d/date 2020 7 30) (task :missed-on)) true))
   (test (= (d/date 2020 7 31) (day-2 :date)) true)
-  (test (= {:text "Talked to Mike & Molly"} ((day-2 :events) 0)) true)
+  (test (= {:title "Talked to Mike & Molly"} ((day-2 :events) 0)) true)
   (let [task ((day-2 :tasks) 0)]
     (test (task :title) "#work - Review open pull requests")
     (test (task :done) true))

--- a/test/plan/parser_test.janet
+++ b/test/plan/parser_test.janet
@@ -28,7 +28,8 @@
     - [x] #work - Review open pull requests
     - [x] #work - Fix the flaky test
     ```)
-  (def plan ((parse plan-string) :plan))
+  (def parse-result (parse plan-string))
+  (def plan (parse-result :plan))
   (def inbox (plan :inbox))
   (def day-1 ((plan :days) 0))
   (def day-2 ((plan :days) 1))
@@ -51,7 +52,9 @@
     (test (not (task :done)) true)
     (test (d/equal? (d/date 2020 7 30) (task :missed-on)) true))
   (test (= (d/date 2020 7 31) (day-2 :date)) true)
-  (test (= {:title "Talked to Mike & Molly"} ((day-2 :events) 0)) true)
+  (let [event ((day-2 :events) 0)]
+    (test (event :title) "Talked to Mike & Molly")
+    (test (empty? (event :body)) true))
   (let [task ((day-2 :tasks) 0)]
     (test (task :title) "#work - Review open pull requests")
     (test (task :done) true))
@@ -193,14 +196,15 @@
       - They moved to a new apartment
     - [x] Fix the lamp
     ```)
-  (def plan ((parse plan-string) :plan))
+  (def parse-result (parse plan-string))
+  (def plan (parse-result :plan))
   (test  (length (plan :days)) 1)
   (let [day ((plan :days) 0)
         event ((day :events) 0)
         task ((day :tasks) 0)]
+    (test (= (d/date 2020 7 30) (day :date)) true)
     (test (event :title) "Talked to Mike & Molly")
     (test ((event :body) 0) "- They moved to a new apartment")
-    (test (= (d/date 2020 7 30) (day :date)) true)
     (test (task :title) "Fix the lamp")
     (test (task :done) true)))
 

--- a/test/plan/parser_test.janet
+++ b/test/plan/parser_test.janet
@@ -204,6 +204,21 @@
     (test (task :title) "Fix the lamp")
     (test (task :done) true)))
 
+(deftest "parses a plan with an event without any tasks"
+  (def plan-string
+    ```
+    # Main TODO
+
+    ## 2020-07-30, Thursday
+
+    - Talked to Mike & Molly
+    ```)
+  (def plan ((parse plan-string) :plan))
+  (test  (length (plan :days)) 1)
+  (let [day ((plan :days) 0)
+        event ((day :events) 0)]
+    (test (event :title) "Talked to Mike & Molly")))
+
 (deftest "returns an error when the plan can't be parsed"
   (def plan-string
     ```

--- a/test/plan/serializer_test.janet
+++ b/test/plan/serializer_test.janet
@@ -15,7 +15,7 @@
       :days @[(day/build-day (d/date 2020 8 3))
               (day/build-day (d/date 2020 8 2))
               (day/build-day (d/date 2020 8 1)
-                             @[(event/build-event "Talked to Mike")]
+                             @[(event/build-event "Talked to Mike" @["- He has a new car"])]
                              @[(task/build-task "Develop photos" false)
                                (task/build-task "Pay bills" true @["- Electricity" "- Water"])
                                (task/build-missed-task "Organize photos" (d/date 2020 7 20))])
@@ -38,6 +38,7 @@
        ## 2020-08-01, Saturday
 
        - Talked to Mike
+         - He has a new car
        - [ ] Develop photos
        - [X] Pay bills
          - Electricity


### PR DESCRIPTION
Events can have the body, the same way tasks do. Example:

```markdown
- Talked with Mike
  - He moved to a new place.
  (It's near the river)
- Saw a wryneck
```